### PR TITLE
🌱 update go.mod to use 1.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/SovereignCloudStack/csmctl
 
-go 1.21.4
+go 1.21
 
 require github.com/spf13/cobra v1.8.0
 


### PR DESCRIPTION
we don't want to pin the exact patch version of go.
